### PR TITLE
restrict argument `converter` for `ConstantVar` to `not void`

### DIFF
--- a/alea/core.nim
+++ b/alea/core.nim
@@ -41,7 +41,7 @@ proc sample*[A](rng: var Random, d: Choice[A]): A =
 proc sample*[A](rng: var Random, c: ClosureVar[A]): A = c.f(rng)
 
 # A few constructors
-converter constant*[A](a: A): ConstantVar[A] = ConstantVar[A](value: a)
+converter constant*[A: not void](a: A): ConstantVar[A] = ConstantVar[A](value: a)
 
 proc uniform*(a, b: float): Uniform = Uniform(a: a, b: b)
 


### PR DESCRIPTION
This works around Nim issue https://github.com/nim-lang/Nim/issues/19877.

I stumbled over this the other day when trying to use cligen's multi dispatch in a program that imported `alea / core`. For the context of the `ConstantVar` I suppose `not void` seems reasonable.


And an unrelated question: I changed the closure types locally to have a `{.gcsafe.}` pragma to make code using `alea` compile if using multiple threads. As long as each thread uses their own `Random` this should be fine, I suppose. But of course if one uses a global `Random` that could maybe lead to trouble. Do you think it's reasonable to make a PR for that? 
