### PR TITLE
`{.gcsafe.}` closures 

### DIFF
--- a/alea/core.nim
+++ b/alea/core.nim
@@ -13,9 +13,21 @@
 # limitations under the License.
 
 type
+  # A closure returning a random number
+  RandomGen* = proc(): float {.gcsafe.}
+  # A closure using an RNG to return a random number
+  RandomArgGen*[A] = proc(rng: var Random): A {.gcsafe.}
+
+  # A closure taking one argument and returning a number
+  ClosureArg*[A, B] = proc(a: A): B {.gcsafe.}
+  # A closure taking two arguments and returning a number
+  Closure2Arg*[A, B, C] = proc(a: A, b: B): C {.gcsafe.}
+  # A closure taking a number and returning a bool
+  ClosureBool*[A] = proc(a: A): bool {.gcsafe.}
+
   # A random number generator
   Random* = object
-    random*: proc(): float
+    random*: RandomGen
   # A generic typeclass for a random var
   RandomVar*[A] = concept x
     var rng: Random
@@ -28,7 +40,7 @@ type
   Choice*[A] = object
     values*: ref seq[A]
   ClosureVar*[A] = object
-    f*: proc(rng: var Random): A
+    f*: RandomArgGen[A]
 
 # How to sample from various concrete instances
 proc sample*[A](rng: var Random, c: ConstantVar[A]): A = c.value
@@ -49,5 +61,5 @@ proc choice*[A](xs: openarray[A]): Choice[A] =
   new result.values
   result.values[] = @xs
 
-proc closure*[A](f: proc(a: var Random): A): ClosureVar[A] =
+proc closure*[A](f: RandomArgGen[A]): ClosureVar[A] =
   result.f = f

--- a/alea/ops.nim
+++ b/alea/ops.nim
@@ -22,7 +22,7 @@ template take*(rng: var Random, x: RandomVar, n: int): auto =
   s
 
 # How to lift a function on values to a function on random variables
-proc map*[A, B](x: RandomVar[A], f: proc(a: A): B): ClosureVar[B] =
+proc map*[A, B](x: RandomVar[A], f: ClosureArg[A, B]): ClosureVar[B] =
   proc inner(rng: var Random): B =
     f(rng.sample(x))
 
@@ -36,7 +36,7 @@ proc map*[A, B](x: RandomVar[A], f: proc(a: A): B): ClosureVar[B] =
 #   result.f = inner
 
 # How to lift a function on two values to a function on random variables
-proc map2*[A, B, C](x: RandomVar[A], y: RandomVar[B], f: proc(a: A, b: B): C): ClosureVar[C] =
+proc map2*[A, B, C](x: RandomVar[A], y: RandomVar[B], f: Closure2Arg[A, B, C]): ClosureVar[C] =
   proc inner(rng: var Random): C =
     f(rng.sample(x), rng.sample(y))
 
@@ -114,7 +114,7 @@ proc clone*[A](r: RandomVar[A]): auto =
   return closure(inner)
 
 # Filter a random variable with respect to a boolean predicate
-proc filter*[A](r: RandomVar[A], p: proc(a: A): bool): auto =
+proc filter*[A](r: RandomVar[A], p: proc(a: A): bool {.gcsafe.}): auto =
   proc inner(rng: var Random): auto =
     var value = rng.sample(r)
     while not p(value):
@@ -128,7 +128,7 @@ proc filter*[A](r: RandomVar[A], p: proc(a: A): bool): auto =
 #  repeated rng.
 # For some reason, here we need to be specific about `s`
 # This constraint should be removed
-proc where*[A](r: RandomVar, s: ClosureVar, p: proc(a: A): bool): auto =
+proc where*[A](r: RandomVar, s: ClosureVar, p: ClosureBool[A]): auto =
   proc inner(rng: var Random): auto =
     var rep = rng.repeat(2)
     var

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -20,9 +20,9 @@ proc isBetween(x, a, b: float): bool = x >= a and x <= b
 
 proc `~`(x, a: float): bool =
   if a != 0:
-    abs((x - a) / a) < 0.1
+    system.abs((x - a) / a) < 0.1
   else:
-    abs(x - a) < 0.1
+    system.abs(x - a) < 0.1
 
 proc isInt(x: float): bool = x.int.float == x
 


### PR DESCRIPTION
First of all, these names are pretty crap. But I couldn't think of good names for these added helper types (to avoid typing `{.gcsafe.}` everywhere) quickly. If you have better ideas, please let me know. :rofl: 

Secondly, I'm not sure whether the regular procedures (which of course don't have to be closures, other than the name implies) that are wrapped in `ops.nim` need / should be `{.gcsafe.}`. 

In my practical use case I only needed to mark the equivalent of `RandomGen` and `RandomArgGen` as `{.gcsafe.}`. 

And for the tests to work nowadays for some reason I had to mark the `abs` call explicitly as `system.abs` as the compiler got confused between that and the `sugar` version. Probably because of the `converter` from `not void` to a `ConstantVar`? 