### PR TITLE
Be explicit about `sugar.lift` parameter being typed instead of untyped

### DIFF
--- a/alea/sugar.nim
+++ b/alea/sugar.nim
@@ -25,7 +25,7 @@ macro lift*[A, B](f: proc(a: A): B): auto =
   result = getAst(inner(id))
 
 # Use an explicit type hint for overloaded functions
-template lift*(f, T: untyped) =
+template lift*(f: typed, T: untyped) =
   func f*(x: RandomVar[T]): auto =
     x.map(proc(t: T): auto = f(t))
 


### PR DESCRIPTION
With Nim's current overloading system, since `lift` has an overload with the first parameter having a type, the first parameter of any `lift` call is assumed to be typed (which is not preferable, discussion about it [here](https://github.com/nim-lang/RFCs/issues/402)). `lift` currently breaks if this behavior is changed, unless we explicitly write `typed`, so do this in case this gets changed.